### PR TITLE
Update to jupytelite.github that has a new xarray version

### DIFF
--- a/src/components/repl.js
+++ b/src/components/repl.js
@@ -6,9 +6,6 @@ import { nord } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 //TODO: We could remove xarrray installation step by requesting xarray to be added to the Pyodide standard lib
 //TODO: Or wait until jupyterlite has streamlined the installation process of user-specified packages
 
-// use for install xarray via micropip
-const preRun =
-  'import%20micropip%0Aawait%20micropip.install%28%5B%27xarray%27%2C%20%27matplotlib%27%5D%29'
 
 // See: https://github.com/jupyterlite/jupyterlite/issues/151
 const preRunCode = `%23%20Import%20packages%0Aimport%20xarray%20as%20xr%0Aimport%20numpy%20as%20np%0Aimport%20pandas%20as%20pd%0A%25matplotlib%20inline`
@@ -90,7 +87,7 @@ export const Repl = () => {
           <AspectRatio ratio={4 / 3}>
             <iframe
               title='repl'
-              src={`${jupyterliteInstance}/?toolbar=1&kernel=python&prerun=${preRun}&prerun-code=${preRunCode}`}
+              src={`${jupyterliteInstance}/?toolbar=1&kernel=python&code=${preRunCode}`}
               alt='demo'
             />
           </AspectRatio>

--- a/src/components/repl.js
+++ b/src/components/repl.js
@@ -15,7 +15,7 @@ const preRunCode = `%23%20Import%20packages%0Aimport%20xarray%20as%20xr%0Aimport
 
 // https://github.com/jobovy/jupyterlite-repl-prerun
 const jupyterliteInstance =
-  'https://jupyterlite-repl-prerun.readthedocs.io/en/latest/lite/repl'
+  'https://jupyterlite.github.io/demo/repl'
 
 const sampleCode = `"""
 To try Xarray in the browser,

--- a/src/components/repl.js
+++ b/src/components/repl.js
@@ -6,7 +6,6 @@ import { nord } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 //TODO: We could remove xarrray installation step by requesting xarray to be added to the Pyodide standard lib
 //TODO: Or wait until jupyterlite has streamlined the installation process of user-specified packages
 
-
 // See: https://github.com/jupyterlite/jupyterlite/issues/151
 const preRunCode = `%23%20Import%20packages%0Aimport%20xarray%20as%20xr%0Aimport%20numpy%20as%20np%0Aimport%20pandas%20as%20pd%0A%25matplotlib%20inline`
 

--- a/src/components/repl.js
+++ b/src/components/repl.js
@@ -14,8 +14,7 @@ const preRun =
 const preRunCode = `%23%20Import%20packages%0Aimport%20xarray%20as%20xr%0Aimport%20numpy%20as%20np%0Aimport%20pandas%20as%20pd%0A%25matplotlib%20inline`
 
 // https://github.com/jobovy/jupyterlite-repl-prerun
-const jupyterliteInstance =
-  'https://jupyterlite.github.io/demo/repl'
+const jupyterliteInstance = 'https://jupyterlite.github.io/demo/repl'
 
 const sampleCode = `"""
 To try Xarray in the browser,

--- a/src/components/repl.js
+++ b/src/components/repl.js
@@ -7,7 +7,7 @@ import { nord } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 //TODO: Or wait until jupyterlite has streamlined the installation process of user-specified packages
 
 // See: https://github.com/jupyterlite/jupyterlite/issues/151
-const preRunCode = `%23%20Import%20packages%0Aimport%20xarray%20as%20xr%0Aimport%20numpy%20as%20np%0Aimport%20pandas%20as%20pd%0A%25matplotlib%20inline`
+const preRunCode = `%23%20Import%20packages%0Aimport%20xarray%20as%20xr%0Aimport%20numpy%20as%20np%0Aimport%20pandas%20as%20pd`
 
 // https://github.com/jobovy/jupyterlite-repl-prerun
 const jupyterliteInstance = 'https://jupyterlite.github.io/demo/repl'


### PR DESCRIPTION
The xarray version on `jupyterlite.github.io` is `2023.12.0`.