### PR TITLE
Fix hydration warning due to nested links

### DIFF
--- a/src/components/mdx/link.js
+++ b/src/components/mdx/link.js
@@ -10,11 +10,9 @@ export const Link = React.forwardRef(function CustomLink(props, ref) {
 
   if (isInternalLink) {
     return (
-      <NextLink href={href} passHref>
-        <ChakraLink ref={ref} {...rest}>
-          {rest.children}
-        </ChakraLink>
-      </NextLink>
+      <ChakraLink ref={ref} {...rest}>
+        {rest.children}
+      </ChakraLink>
     )
   }
 

--- a/src/components/mdx/link.js
+++ b/src/components/mdx/link.js
@@ -10,14 +10,14 @@ export const Link = React.forwardRef(function CustomLink(props, ref) {
 
   if (isInternalLink) {
     return (
-      <ChakraLink ref={ref} {...rest}>
+      <ChakraLink as={NextLink} ref={ref} {...rest}>
         {rest.children}
       </ChakraLink>
     )
   }
 
   return (
-    <ChakraLink isExternal {...rest} ref={ref}>
+    <ChakraLink isExternal {...rest} as={NextLink} ref={ref}>
       {rest.children}
       {useExternalIcon && <ExternalLinkIcon mx='2px' />}
     </ChakraLink>

--- a/src/data/sponsors.js
+++ b/src/data/sponsors.js
@@ -4,7 +4,7 @@ export const Sponsors = [
   {
     name: 'CZI',
     logo: '/Chan_Zuckerberg_Initiative.svg',
-    url: 'https://chanzuckerberg.com//',
+    url: 'https://chanzuckerberg.com/',
   },
   { name: 'NVIDIA', logo: '/Nvidia_logo.svg', url: 'https://www.nvidia.com/' },
 ]


### PR DESCRIPTION
I found this warning distracting when building out the Pangeo docs, so I thought I'd fix it here too since the code is the same.