### PR TITLE
UI: Make banner width match content + round corners

### DIFF
--- a/src/components/banner.js
+++ b/src/components/banner.js
@@ -5,6 +5,7 @@ import {
   AlertTitle,
   Box,
   CloseButton,
+  Container,
   useDisclosure,
 } from '@chakra-ui/react'
 
@@ -16,34 +17,41 @@ export const Banner = ({ title, description, children }) => {
   } = useDisclosure({ defaultIsOpen: true })
 
   return isVisible ? (
-    <Box pt={16} px={20}>
-      <Alert
-        status='info'
-        variant='solid'
-        alignItems='flex-start' // Align icon nicely with multi-line text
-      >
-        <AlertIcon />
-        <Box flex='1' ml={3}>
-          {' '}
-          {/* Container for text content, allows vertical flow */}
-          <AlertTitle>{title}</AlertTitle>
-          {description && (
-            <AlertDescription mt={1}>{description}</AlertDescription>
-          )}
-          <Box mt={2}>
+    <Box pt={16}>
+      {' '}
+      {/* This Box provides top padding to clear the header */}
+      <Container maxW='container.lg'>
+        {' '}
+        {/* Constrains the width of the banner */}
+        <Alert
+          status='info'
+          variant='solid'
+          alignItems='flex-start' // Align icon nicely with multi-line text
+          borderRadius='md' // Added rounded corners
+        >
+          <AlertIcon />
+          <Box flex='1' ml={3}>
             {' '}
-            {/* Wrapper for children, e.g., links */}
-            {children}
+            {/* Container for text content, allows vertical flow */}
+            <AlertTitle>{title}</AlertTitle>
+            {description && (
+              <AlertDescription mt={1}>{description}</AlertDescription>
+            )}
+            <Box mt={2}>
+              {' '}
+              {/* Wrapper for children, e.g., links */}
+              {children}
+            </Box>
           </Box>
-        </Box>
-        <CloseButton
-          position='absolute' // Position absolutely within the Alert
-          alignSelf='flex-start'
-          right='8px' // Adjust as needed
-          top='8px' // Adjust as needed
-          onClick={onClose}
-        />
-      </Alert>
+          <CloseButton
+            position='absolute' // Position absolutely within the Alert
+            alignSelf='flex-start'
+            right='8px' // Adjust as needed
+            top='8px' // Adjust as needed
+            onClick={onClose}
+          />
+        </Alert>
+      </Container>
     </Box>
   ) : (
     <></>


### PR DESCRIPTION
Adjusting the styling of the banner on the main page in two ways:

n.b.: This PR basically purely a product of AI code changes
**Width:**

Prior to this PR the banner was wider than the rest of the content

**Corners:**

I rounded the corners for visual consistency with the buttons with rounded corners lower down the page


## Old:
<img width="1366" alt="image" src="https://github.com/user-attachments/assets/50fc1c65-24bb-433d-b44f-b881e546046c" />


## New:

<img width="1050" alt="image" src="https://github.com/user-attachments/assets/a76c3baf-5aef-4956-b2fb-76197dfc9960" />


## AI

This was a vibe-coded change (i.e. I used gemini to figure out the web component. I did manually review the changes and verified that they work on desktop. The AI extension justified the changes like so:

> 
> **Import Container:** We've added Container to the imports from `@chakra-ui/react`.
> **Outer Box Padding:** The `px={20}` (horizontal padding) was removed from the outermost Box. The `pt={16}` (top padding) remains to ensure the banner is positioned correctly below your header.
> **Added Container:** The Alert component is now wrapped with `<Container maxW='container.lg'>`. This will constrain the banner's width to container.lg (typically 1024px in Chakra UI's default theme), aligning it with how your blog content is likely constrained. The Container also handles its own responsive horizontal padding.
> **Rounded Corners:** The `borderRadius='md'` prop has been added to the Alert component. You can change 'md' to other values like 'sm', 'lg', or a specific pixel/rem value (e.g., '8px') if you prefer a different amount of rounding.
> 

