### PR TITLE
less strict iframe options

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -31,8 +31,6 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    X-Frame-Options = "DENY"
-    X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
 


### PR DESCRIPTION
Closes: #813  (though im not sure if the build config will affect the PR build)

by allowing linking of iframes from anywhere, and anywhere to link an iframe of us. we could also change it to `SAMEORIGIN` to allow us to use iframes internally, but no one can make an iframe of us. But I like this more permissive model, it would have made it easier for me to embed the xarray repr from this site in the post i wrote on the napari blog.

I also removed `X-XSS-PROTECTION` which is non-standard, deprecated and recommended to be removed: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection


heads up to @scottyhq if you have opinions here